### PR TITLE
Updated requirments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Markdown>=2.3.1
 PyYAML>=3.11
 requests>=2.8.1
 sleekxmpp>=1.3.1
-smoke-zephyr==1.0.1
+smoke-zephyr>=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ Markdown>=2.3.1
 PyYAML>=3.11
 requests>=2.8.1
 sleekxmpp>=1.3.1
-smoke-zephyr>=1.0.1
+smoke-zephyr>=1.0.3
+


### PR DESCRIPTION
Updated requirments so it will pull the latest version of smoke-zephyr. Have not seen any issues with cassie-bot running with smoke-zephyr 1.0.3