### PR TITLE
Error handling for shlex.split

### DIFF
--- a/cassie/bot/xmpp.py
+++ b/cassie/bot/xmpp.py
@@ -203,7 +203,12 @@ class CassieXMPPBot(sleekxmpp.ClientXMPP):
 			if not guser in self.authorized_users:
 				return
 			user_lvl = self.authorized_users[guser].level
-		arguments = shlex.split(message)
+		try:
+			arguments = shlex.split(message)
+		except ValueError as error:
+			self.logger.warning('failed to split message: ' + message + ' for user ' + jid.bare)
+			self.send_message_formatted(jid, "Cannot parse message because: " + str(error), msg['type'])
+			return
 		command = arguments.pop(0)
 		command = command[1:]
 		if msg['type'] == 'groupchat':


### PR DESCRIPTION
Due to the way shlex.split() breaks up a string by default, it was found the bot was not properly handling messages that did not have a closing quotations, such as `!help '`. This PR will log an error when the message cannot be split due to a ValueError occurring during the shlex split, log it according and inform the jid that it was unable to parse the message correctly and log for a command.

 - [ ] Cassie-bot now properly logs shlex.split() value error
 - [ ] Cassie-bot reply to the jid, stating it was unable to parse the message
